### PR TITLE
Remove removed option forceSuggestionFixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'warn',
         '@typescript-eslint/no-useless-constructor': 'error',
         '@typescript-eslint/no-misused-promises': 'error', // warn for `if (promise)` and `forEach(async () => ...)` (note: forEach takes void func)
-        '@typescript-eslint/prefer-nullish-coalescing': ['warn', { forceSuggestionFixer: true }],
+        '@typescript-eslint/prefer-nullish-coalescing': 'warn',
         '@typescript-eslint/prefer-optional-chain': 'warn',
         '@typescript-eslint/unbound-method': 'error', // Warn for unbound this of `foo(classInstance.method)` (`.bind(instance)` is required)
 


### PR DESCRIPTION
Option `forceSuggestionFixer` is removed in typescript-eslint/eslint-plugin v3.0.0

```
Error: .eslintrc.js » eslint-config-codetakt-ts#overrides[1]:
	Configuration for rule "@typescript-eslint/prefer-nullish-coalescing" is invalid:
	Value {"forceSuggestionFixer":true} should NOT have additional properties.
```

#### Environment
- eslint-config-codetakt-ts: 2.0.4
- ESLint: 8.28.8
- typescript-eslint/eslint-plugin: 5.44.0